### PR TITLE
Added .wp-block-embed for center aligned items

### DIFF
--- a/css/blocks.css
+++ b/css/blocks.css
@@ -4,6 +4,7 @@
 .entry-content h3,
 .entry-content h4,
 .wp-block-image,
+.wp-block-embed,
 .wp-block-gallery,
 .wp-block-video,
 .wp-block-quote,


### PR DESCRIPTION
oEmbed blocks that are center-aligned were getting pushed outside of the content area because they didn't have a max-width.

See here:
![image](https://user-images.githubusercontent.com/930724/34448886-f5849280-eca6-11e7-9c61-6e8e5044a3d6.png)
